### PR TITLE
Fix typo on AISP README

### DIFF
--- a/resources-and-data-models/aisp/README.md
+++ b/resources-and-data-models/aisp/README.md
@@ -59,7 +59,7 @@ The API endpoints for these resources, and their mandatory/conditional/optional 
 
 Definitions for Mandatory, Conditional and Optional are given in the [Read/Write Data API Profile](../../profiles/read-write-data-api-profile.md#categorisation-of-implementation-requirements).
 
-## Account and Transactionns Resource Compatibility
+## Account and Transactions Resource Compatibility
 
 |  | |Read-Write API Profile |Read-Write API Profile |Read-Write API Profile |Account and Transaction API Profile |Account and Transaction API Profile |Account and Transaction API Profile |
 | --- |--- |--- |--- |--- |--- |--- |--- |


### PR DESCRIPTION
Fix typo found on `AISP Resources and Data Models` page.